### PR TITLE
Adjust list indentation based on font and level

### DIFF
--- a/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
+++ b/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
@@ -41,10 +41,8 @@ open class MarkdownList: MarkdownLevelElement {
     attributedString.replaceCharacters(in: range, with: indicator)
 
     let calcFont = font ?? MarkdownParser.defaultFont
-    let nonListSectionRange = NSRange(location: 0, length: range.length)
 
     let headIndent = (indicator as NSString).size(withAttributes: [.font: calcFont]).width
-    attributedString.addAttributes([.paragraphStyle : paragraphStyle(spacing: calcFont.pointSize / 2, headIndent: headIndent)], range: nonListSectionRange)
     attributedString.addAttributes([.paragraphStyle : paragraphStyle(spacing: calcFont.pointSize / 3, headIndent: headIndent)], range: range)
   }
 

--- a/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
+++ b/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
@@ -39,11 +39,12 @@ open class MarkdownList: MarkdownLevelElement {
       let offset = levelIndicatorOffsetList[level] else { return }
     let indicator = "\(offset)\(indicatorIcon)"
     attributedString.replaceCharacters(in: range, with: indicator)
+    let updatedRange = NSRange(location: range.location, length: indicator.utf16.count)
 
     let calcFont = font ?? MarkdownParser.defaultFont
 
     let headIndent = (indicator as NSString).size(withAttributes: [.font: calcFont]).width
-    attributedString.addAttributes([.paragraphStyle : paragraphStyle(spacing: calcFont.pointSize / 3, headIndent: headIndent)], range: range)
+    attributedString.addAttributes([.paragraphStyle : paragraphStyle(spacing: calcFont.pointSize / 3, headIndent: headIndent)], range: updatedRange)
   }
 
   private func paragraphStyle(spacing: CGFloat, headIndent: CGFloat) -> NSMutableParagraphStyle {

--- a/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
+++ b/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
@@ -42,14 +42,16 @@ open class MarkdownList: MarkdownLevelElement {
 
     let calcFont = font ?? MarkdownParser.defaultFont
     let nonListSectionRange = NSRange(location: 0, length: range.length)
-    attributedString.addAttributes([.paragraphStyle : defaultParagraphStyle(spacing: calcFont.pointSize / 2)], range: nonListSectionRange)
-    attributedString.addAttributes([.paragraphStyle : defaultParagraphStyle(spacing: calcFont.pointSize / 3)], range: range)
+
+    let headIndent = (indicator as NSString).size(withAttributes: [.font: calcFont]).width
+    attributedString.addAttributes([.paragraphStyle : paragraphStyle(spacing: calcFont.pointSize / 2, headIndent: headIndent)], range: nonListSectionRange)
+    attributedString.addAttributes([.paragraphStyle : paragraphStyle(spacing: calcFont.pointSize / 3, headIndent: headIndent)], range: range)
   }
 
-  private func defaultParagraphStyle(spacing: CGFloat) -> NSMutableParagraphStyle {
+  private func paragraphStyle(spacing: CGFloat, headIndent: CGFloat) -> NSMutableParagraphStyle {
     let paragraphStyle = NSMutableParagraphStyle()
     paragraphStyle.firstLineHeadIndent = 0
-    paragraphStyle.headIndent = 16
+    paragraphStyle.headIndent = headIndent
     paragraphStyle.paragraphSpacing = spacing
     return paragraphStyle
   }

--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -95,7 +95,7 @@ open class MarkdownParser {
     self.color = color
     
     self.header = MarkdownHeader()
-    self.list = MarkdownList()
+    self.list = MarkdownList(font: font)
     self.quote = MarkdownQuote()
     self.link = MarkdownLink()
     self.automaticLink = MarkdownAutomaticLink()


### PR DESCRIPTION
Wrapped lines on bulleted text were only aligned correctly when using the default font and first level. Now all levels are aligned properly.

![simulator_screenshot_70A5579F-2669-412A-99C8-8FF70152451A](https://user-images.githubusercontent.com/631051/174292162-f1965b3e-ff17-4523-810c-8646bb74e1d5.png)
 