### PR TITLE
Add e-mail support in links.

### DIFF
--- a/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
+++ b/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
@@ -8,10 +8,18 @@
 import Foundation
 
 open class MarkdownLink: MarkdownLinkElement {
+  private struct Constants {
+    /// The RFC 5322 official standard email regex
+    ///
+    /// Source: https://emailregex.com/
+    static let emailRegex = "^(?:[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[A-Za-z0-9-]*[A-Za-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$"
+    static let emailScheme = "mailto:"
+  }
 
   fileprivate static let regex = "(\\[[^\\]]+)(\\]\\([^\\s]+)?\\)"
 
   private let schemeRegex = "([a-z]{2,20}):\\/\\/"
+  private var defaultSchemeOrHttps: String { defaultScheme ?? "https://" }
 
   open var font: MarkdownFont?
   open var color: MarkdownColor?
@@ -33,16 +41,16 @@ open class MarkdownLink: MarkdownLinkElement {
   open func formatText(_ attributedString: NSMutableAttributedString, range: NSRange, link: String) {
     let regex = try? NSRegularExpression(pattern: schemeRegex, options: .caseInsensitive)
     let hasScheme = regex?.firstMatch(
-        in: link,
-        options: .anchored,
-        range: NSRange(0..<link.count)
+      in: link,
+      options: .anchored,
+      range: NSRange(0..<link.count)
     ) != nil
 
-    let fullLink = hasScheme ? link : "\(defaultScheme ?? "https://")\(link)"
+    let fullLink = hasScheme ? link : "\(defaultSchemeOrHttps)\(link)"
 
     guard let encodedLink = fullLink.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else { return }
-    guard let url = URL(string: fullLink) ?? URL(string: encodedLink) else { return }
-    attributedString.addAttribute(NSAttributedString.Key.link, value: url, range: range)
+    guard let url = URL(string: link) ?? URL(string: encodedLink), let transformedURL = transformedURL(url) else { return }
+    attributedString.addAttribute(NSAttributedString.Key.link, value: transformedURL, range: range)
   }
 
   open func match(_ match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {
@@ -61,15 +69,15 @@ open class MarkdownLink: MarkdownLinkElement {
     var numberOfOpeningParantheses = 0
     var numberOfClosingParantheses = 0
     for (index, character) in urlString.enumerated() {
-        switch character {
-        case "(": numberOfOpeningParantheses += 1
-        case ")": numberOfClosingParantheses += 1
-        default: continue
-        }
-        if numberOfClosingParantheses > numberOfOpeningParantheses {
-            urlString = NSString(string: urlString).substring(with: NSRange(0..<index))
-            break
-        }
+      switch character {
+      case "(": numberOfOpeningParantheses += 1
+      case ")": numberOfClosingParantheses += 1
+      default: continue
+      }
+      if numberOfClosingParantheses > numberOfOpeningParantheses {
+        urlString = NSString(string: urlString).substring(with: NSRange(0..<index))
+        break
+      }
     }
 
     // Remove opening parantheses
@@ -103,5 +111,20 @@ open class MarkdownLink: MarkdownLinkElement {
 
   open func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange) {
     attributedString.addAttributes(attributes, range: range)
+  }
+
+  /// - Returns: A transformed version of the given `URL`, adding e-mail or default scheme.
+  /// Ignores URLs which already has a scheme.
+  private func transformedURL(_ url: URL) -> URL? {
+    guard url.scheme == nil else {
+      return url
+    }
+
+    let urlString = url.absoluteString
+    return URL(string: (isEmailAddress(urlString) ? Constants.emailScheme : defaultSchemeOrHttps) + urlString)
+  }
+
+  private func isEmailAddress(_ string: String) -> Bool {
+    return string.range(of: Constants.emailRegex, options: .regularExpression) != nil
   }
 }


### PR DESCRIPTION
The e-mail addresses were getting parsed as links, but opening the e-mail domain address rather than using `mailto:` scheme. Luckily someone else has solved this problem already: https://github.com/bmoliveira/MarkdownKit/compare/master...Accedo-Products:MarkdownKit:master#diff-70c01aef9f93f48524c062f6d9df4d18063dab97644d5db3bc1ca9c00e693481